### PR TITLE
Make that events invoked in coroutines get invoked within the main thread

### DIFF
--- a/docs/basic_node.md
+++ b/docs/basic_node.md
@@ -193,7 +193,7 @@ namespace Scripts
                         // NullReferenceException getting thrown.
                         if (newTip.Index > 0)
                         {
-                            _blockUpdatedEvent.Invoke(newTip);
+                            _agent.RunOnMainThread(() => _blockUpdatedEvent.Invoke(newTip));
                         }
                     }
                 }
@@ -235,7 +235,7 @@ BlockRenderer = (oldTip, newTip) =>
 {
     if (newTip.Index > 0)
     {
-        _blockUpdatedEvent.Invoke(newTip);
+        _agent.RunOnMainThread(() => _blockUpdatedEvent.Invoke(newTip));
     }
 }
 ```

--- a/docs/click_counter.md
+++ b/docs/click_counter.md
@@ -144,7 +144,7 @@ namespace Scripts
                         // NullReferenceException getting thrown.
                         if (newTip.Index > 0)
                         {
-                            _blockUpdatedEvent.Invoke(newTip);
+                            _agent.RunOnMainThread(() => _blockUpdatedEvent.Invoke(newTip));
                         }
                     }
                 }
@@ -473,7 +473,7 @@ namespace Scripts
                         // NullReferenceException getting thrown.
                         if (newTip.Index > 0)
                         {
-                            _blockUpdatedEvent.Invoke(newTip);
+                            _agent.RunOnMainThread(() => _blockUpdatedEvent.Invoke(newTip));
                         }
                     }
                 },
@@ -484,7 +484,7 @@ namespace Scripts
                         // Invoke the event handler only if the state is updated.
                         if (nextStates.GetState(context.Signer) is Bencodex.Types.Dictionary bdict)
                         {
-                            _totalCountUpdatedEvent.Invoke(new CountState(bdict));
+                            _agent.RunOnMainThread(() => _totalCountUpdatedEvent.Invoke(new CountState(bdict)));
                         }
                     }
                 }

--- a/docs/scoreboard.md
+++ b/docs/scoreboard.md
@@ -229,7 +229,7 @@ namespace Scripts
                         // NullReferenceException getting thrown.
                         if (newTip.Index > 0)
                         {
-                            _blockUpdatedEvent.Invoke(newTip);
+                            _agent.RunOnMainThread(() => _blockUpdatedEvent.Invoke(newTip));
                         }
                     }
                 },
@@ -240,7 +240,7 @@ namespace Scripts
                         // Invoke the event handler only if the state is updated.
                         if (nextStates.GetState(context.Signer) is Bencodex.Types.Dictionary bdict)
                         {
-                            _totalCountUpdatedEvent.Invoke(new CountState(bdict));
+                            _agent.RunOnMainThread(() => _totalCountUpdatedEvent.Invoke(new CountState(bdict)));
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #40. The events must be invoked in the main thread in order for them to correctly work when the scene is run in the editor.