### PR TITLE
Resolve Start mining after Swarm<T>.StartAsync()

### DIFF
--- a/Libplanet.Unity/Agent.cs
+++ b/Libplanet.Unity/Agent.cs
@@ -133,7 +133,7 @@ namespace Libplanet.Unity
         private void Start()
         {
             _swarmRunnerCo = StartCoroutine(_swarmRunner.CoSwarmRunner());
-            _minerCo = StartCoroutine(_miner.CoStart());
+            _minerCo = StartCoroutine(_miner.CoStart(_swarmRunner));
             _processActionsCo = StartCoroutine(_actionWorker.CoProcessActions());
         }
 

--- a/Libplanet.Unity/Miner.cs
+++ b/Libplanet.Unity/Miner.cs
@@ -41,11 +41,14 @@ namespace Libplanet.Unity
         /// <summary>
         /// Processes mining and wait.
         /// </summary>
+        /// <param name="swarm">The <see cref="SwarmRunner"/> to check for preload. </param>
         /// <returns>Mining Coroutine.</returns>
-        public IEnumerator CoStart()
+        public IEnumerator CoStart(SwarmRunner swarm)
         {
             while (true)
             {
+                yield return new WaitUntil(() => swarm.PreloadTask_ended);
+
                 var task = Task.Run(async () => await Mine());
                 yield return new WaitUntil(() => task.IsCompleted);
 

--- a/Libplanet.Unity/Miner.cs
+++ b/Libplanet.Unity/Miner.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Unity
         {
             while (true)
             {
-                yield return new WaitUntil(() => swarm.PreloadTask_ended);
+                yield return new WaitUntil(() => swarm.IsPreloaded);
 
                 var task = Task.Run(async () => await Mine());
                 yield return new WaitUntil(() => task.IsCompleted);

--- a/Libplanet.Unity/SwarmRunner.cs
+++ b/Libplanet.Unity/SwarmRunner.cs
@@ -66,11 +66,6 @@ namespace Libplanet.Unity
 
             yield return new WaitUntil(() => bootstrapTask.IsCompleted);
 
-            if (!IsPreloaded)
-            {
-                IsPreloaded = true;
-            }
-
             Debug.Log("PreloadingStarted event was invoked");
 
             DateTimeOffset started = DateTimeOffset.UtcNow;
@@ -86,6 +81,11 @@ namespace Libplanet.Unity
             });
 
             yield return new WaitUntil(() => swarmPreloadTask.IsCompleted);
+            if (!IsPreloaded)
+            {
+                IsPreloaded = true;
+            }
+
             DateTimeOffset ended = DateTimeOffset.UtcNow;
 
             if (swarmPreloadTask.Exception is Exception exc)

--- a/Libplanet.Unity/SwarmRunner.cs
+++ b/Libplanet.Unity/SwarmRunner.cs
@@ -37,6 +37,11 @@ namespace Libplanet.Unity
             _cancellationTokenSource = new CancellationTokenSource();
         }
 
+        /// <summary>
+        /// A flag for whether the swarmPreloadTask has completed.
+        /// </summary>
+        public bool PreloadTask_ended { get; set; }
+
         private PrivateKey PrivateKey { get; set; }
 
         /// <summary>
@@ -60,6 +65,11 @@ namespace Libplanet.Unity
             });
 
             yield return new WaitUntil(() => bootstrapTask.IsCompleted);
+
+            if (!PreloadTask_ended)
+            {
+                PreloadTask_ended = true;
+            }
 
             Debug.Log("PreloadingStarted event was invoked");
 

--- a/Libplanet.Unity/SwarmRunner.cs
+++ b/Libplanet.Unity/SwarmRunner.cs
@@ -40,7 +40,7 @@ namespace Libplanet.Unity
         /// <summary>
         /// A flag for whether the swarmPreloadTask has completed.
         /// </summary>
-        public bool PreloadTask_ended { get; set; }
+        public bool IsPreloaded { get; set; }
 
         private PrivateKey PrivateKey { get; set; }
 
@@ -66,9 +66,9 @@ namespace Libplanet.Unity
 
             yield return new WaitUntil(() => bootstrapTask.IsCompleted);
 
-            if (!PreloadTask_ended)
+            if (!IsPreloaded)
             {
-                PreloadTask_ended = true;
+                IsPreloaded = true;
             }
 
             Debug.Log("PreloadingStarted event was invoked");


### PR DESCRIPTION
Related to https://github.com/planetarium/UniLibplanet/issues/38

The completion of the preload task is stored in the `swarmRunner` as a bool variable called `PreloadTask_ended`
Pass swarmRunner to `miner.CoStart(_swarmRunner)` and wait until `PreloadTask_ended` value is true.
This solves the precedent relationship.