### PR TITLE
Add EventHandler to know Preloaded completed

### DIFF
--- a/Libplanet.Unity/Agent.cs
+++ b/Libplanet.Unity/Agent.cs
@@ -132,9 +132,18 @@ namespace Libplanet.Unity
 
         private void Start()
         {
+            _swarmRunner.IsPreloadedChanged += StartMiner;
             _swarmRunnerCo = StartCoroutine(_swarmRunner.CoSwarmRunner());
-            _minerCo = StartCoroutine(_miner.CoStart(_swarmRunner));
             _processActionsCo = StartCoroutine(_actionWorker.CoProcessActions());
+        }
+
+        /// <summary>
+        /// EventHandler wether IsPreloaded changed.
+        /// </summary>
+        private void StartMiner()
+        {
+            Debug.Log("Triggered IsPreloadedChanged : Start Miner");
+            _minerCo = StartCoroutine(_miner.CoStart());
         }
 
         private void OnApplicationQuit()

--- a/Libplanet.Unity/Miner.cs
+++ b/Libplanet.Unity/Miner.cs
@@ -41,14 +41,11 @@ namespace Libplanet.Unity
         /// <summary>
         /// Processes mining and wait.
         /// </summary>
-        /// <param name="swarm">The <see cref="SwarmRunner"/> to check for preload. </param>
         /// <returns>Mining Coroutine.</returns>
-        public IEnumerator CoStart(SwarmRunner swarm)
+        public IEnumerator CoStart()
         {
             while (true)
             {
-                yield return new WaitUntil(() => swarm.IsPreloaded);
-
                 var task = Task.Run(async () => await Mine());
                 yield return new WaitUntil(() => task.IsCompleted);
 

--- a/Libplanet.Unity/SwarmRunner.cs
+++ b/Libplanet.Unity/SwarmRunner.cs
@@ -38,6 +38,16 @@ namespace Libplanet.Unity
         }
 
         /// <summary>
+        /// EventHandler checked if IsPreloaded has changed.
+        /// </summary>
+        public delegate void EventHandler();
+
+        /// <summary>
+        /// Event checked if IsPreloaded has changed.
+        /// </summary>
+        public event EventHandler? IsPreloadedChanged;
+
+        /// <summary>
         /// A flag for whether the swarmPreloadTask has completed.
         /// </summary>
         public bool IsPreloaded { get; set; }
@@ -84,6 +94,8 @@ namespace Libplanet.Unity
             if (!IsPreloaded)
             {
                 IsPreloaded = true;
+                Debug.Log("PreloadTask Completed");
+                IsPreloadedChanged?.Invoke();
             }
 
             DateTimeOffset ended = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Add EventHandler to know Preloaded completed. 
When an event occurs, `StartMiner` is executed.
Regardless of the argument of `_miner.CoStart()`
