### PR TITLE
Fix typo in the tutorial documentation

### DIFF
--- a/docs/basic_node.md
+++ b/docs/basic_node.md
@@ -23,7 +23,7 @@ Unity Editor window to show up.
 
 Download the latest [UniLibplanet.unitypackage][UniLibplanet releases] from
 the [UniLibplanet] [GitHub] repository.  From Unity Editor,
-select `Assets` → `Import Package` → `Custom Pakcage` from the top menu
+select `Assets` → `Import Package` → `Custom Package` from the top menu
 and select the downloaded [UniLibplanet.unitypackage] file.  Confirm with
 `Import` to import everything.
 


### PR DESCRIPTION
fixes a small typo in the documentation. 
`Pakcage` -> `Package`